### PR TITLE
👷 add `build` action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release
+  build-macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,30 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ssh-sign_linux-x64
+        path: ./target/release/ssh-sign
   build-macos:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ssh-sign_macos-x64
+        path: ./target/release/ssh-sign
   build-windows:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --release
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ssh-sign_windows-x64.exe
+        path: ./target/release/ssh-sign.exe


### PR DESCRIPTION
A GitHub Action to build ssh-sign for macOS, linux, Windows and upload the artifacts.